### PR TITLE
fix: add defensive array checks for meeting types and languages

### DIFF
--- a/src/components/MeetingCard.tsx
+++ b/src/components/MeetingCard.tsx
@@ -34,6 +34,14 @@ interface MeetingCardProps {
 }
 
 export const MeetingCard = ({ meeting }: MeetingCardProps) => {
+  if (!meeting) {
+    return <div>Loading...</div>;
+  }
+
+    // Ensure types and languages are arrays with a default empty array
+    const types = Array.isArray(meeting.types) ? meeting.types : [];
+    const languages = Array.isArray(meeting.languages) ? meeting.languages : [];
+
   return (
     <Box
       borderWidth="1px"
@@ -106,7 +114,7 @@ export const MeetingCard = ({ meeting }: MeetingCardProps) => {
 
         {/* Tags */}
         <HStack wrap="wrap" gap={2}>
-          {meeting.types.map((type) => (
+          {types.map((type) => (
             <Tooltip key={type} content={BADGE_DESCRIPTIONS[type] || type}>
               <Badge
                 colorScheme="blue"
@@ -119,7 +127,7 @@ export const MeetingCard = ({ meeting }: MeetingCardProps) => {
               </Badge>
             </Tooltip>
           ))}
-          {meeting.languages.map((lang) => (
+          {languages.map((lang) => (
             <Tooltip key={lang} content={BADGE_DESCRIPTIONS[lang] || lang}>
               <Badge
                 colorScheme="green"


### PR DESCRIPTION
# Add defensive programming for meeting types

## Problem
The MeetingCard component was throwing runtime errors when `meeting.types` or `meeting.languages` were undefined, despite being defined as string arrays in the TypeScript interface.

## Solution
Added defensive programming checks to ensure we always have arrays to map over, even if the incoming data doesn't match our TypeScript expectations.

### Changes
- Added `Array.isArray()` checks for both `types` and `languages`
- Provided empty array fallbacks when data is malformed
- Improved component resilience across different environments

## Testing
- [ ] Verified component renders correctly with valid meeting data
- [ ] Verified component handles undefined/malformed data gracefully
- [ ] No console errors when rendering meetings list

## Impact
- 🐛 Fixes runtime errors in MeetingCard component
- 💪 Improves application stability
- 🔄 No functional changes when data is correct