### PR TITLE
Refactoring Meeting Card to display categories instead of types

### DIFF
--- a/src/components/MeetingCard.tsx
+++ b/src/components/MeetingCard.tsx
@@ -2,6 +2,7 @@ import { FaExternalLinkAlt } from "react-icons/fa"
 
 import { Tooltip } from "@/components/ui/tooltip"
 import type { Meeting } from "@/meetings-utils"
+import { TYPE, FORMATS, FEATURES, COMMUNITIES } from "@/meetingTypes"
 import {
   Badge,
   Box,
@@ -13,20 +14,27 @@ import {
   VStack,
 } from "@chakra-ui/react"
 
-const BADGE_DESCRIPTIONS: Record<string, string> = {
-  POA: "Proof of Attendance",
-  ST: "Step Meeting",
-  TR: "Tradition Meeting",
-  SP: "Speaker Meeting",
-  BE: "Beginner Meeting",
-  O: "Open Meeting - Anyone may attend",
-  D: "Discussion Meeting",
-  C: "Closed Meeting - AA Members Only",
-  EN: "English Speaking",
-  ABSI: "Absolutely Sober",
-  LS: "Living Sober",
-  Y: "Young People",
-  B: "Big Book Study",
+const DESCRIPTIONS: Record<string, string> = {
+  ...TYPE,
+  ...FORMATS,
+  ...FEATURES,
+  ...COMMUNITIES,
+}
+
+interface CategoryColors {
+  features: string
+  formats: string
+  languages: string
+  communities: string
+  type: string
+}
+
+const CATEGORY_COLORS: CategoryColors = {
+  features: "purple",
+  formats: "blue",
+  languages: "green",
+  communities: "orange",
+  type: "cyan"
 }
 
 interface MeetingCardProps {
@@ -34,6 +42,9 @@ interface MeetingCardProps {
 }
 
 export const MeetingCard = ({ meeting }: MeetingCardProps) => {
+  // Create arrays of categories that exist in the meeting
+  const categories = ['features', 'formats', 'languages', 'communities', 'type'] as const
+  
   return (
     <Box
       borderWidth="1px"
@@ -104,34 +115,25 @@ export const MeetingCard = ({ meeting }: MeetingCardProps) => {
           </Box>
         )}
 
-        {/* Tags */}
+        {/* Categories */}
         <HStack wrap="wrap" gap={2}>
-          {/* {meeting.types.map((type) => (
-            <Tooltip key={type} content={BADGE_DESCRIPTIONS[type] || type}>
-              <Badge
-                colorScheme="blue"
-                variant="subtle"
-                px={2}
-                py={1}
-                borderRadius="full"
-              >
-                {type}
-              </Badge>
-            </Tooltip>
-          ))} */}
-          {meeting.languages.map((lang) => (
-            <Tooltip key={lang} content={BADGE_DESCRIPTIONS[lang] || lang}>
-              <Badge
-                colorScheme="green"
-                variant="subtle"
-                px={2}
-                py={1}
-                borderRadius="full"
-              >
-                {lang}
-              </Badge>
-            </Tooltip>
-          ))}
+          {categories.map(category => 
+            meeting[category]?.length > 0 && (
+              meeting[category].map((item: string) => (
+                <Tooltip key={`${category}-${item}`} content={DESCRIPTIONS[item] || item}>
+                  <Badge
+                    colorScheme={CATEGORY_COLORS[category]}
+                    variant="subtle"
+                    px={2}
+                    py={1}
+                    borderRadius="full"
+                  >
+                    {item}
+                  </Badge>
+                </Tooltip>
+              ))
+            )
+          )}
         </HStack>
       </VStack>
     </Box>

--- a/src/meetings-utils.ts
+++ b/src/meetings-utils.ts
@@ -21,6 +21,10 @@ export interface Meeting {
   sortRTCTime: string
   startDateUTC: string
   types: string[]
+  features: string[]
+  formats: string[]
+  communities: string[]
+  type: string[]
 }
 
 export interface FilterParams {

--- a/src/routes/meetings-filtered.tsx
+++ b/src/routes/meetings-filtered.tsx
@@ -10,6 +10,7 @@ import type { Route } from "./+types/meetings-filtered"
 export async function clientLoader({ request }: Route.ClientLoaderArgs) {
   const { searchParams } = new URL(request.url)
   const meetings = await getMeetings(buildFilter(searchParams))
+  console.log(meetings)
   return { meetings }
 }
 


### PR DESCRIPTION
# Refactor Meeting Card Component to Use Centralized Category Definitions

## Problem
The MeetingCard component was using a hardcoded `BADGE_DESCRIPTIONS` object for meeting categories, leading to:
- Duplicate data definitions
- Potential inconsistencies with the source of truth
- Less maintainable code

## Solution
Refactored the component to use the centralized category definitions from `meetingTypes.ts`:
- Removed hardcoded `BADGE_DESCRIPTIONS`
- Imported category definitions (`TYPE`, `FORMATS`, `FEATURES`, `COMMUNITIES`)
- Created a merged `DESCRIPTIONS` object with proper TypeScript typing
- Implemented dynamic category display

### Changes

```
typescript
// Removed hardcoded BADGE_DESCRIPTIONS
// Added imports from meetingTypes
import { TYPE, FORMATS, FEATURES, COMMUNITIES } from "@/meetingTypes"
// Created properly typed merged descriptions
const DESCRIPTIONS: Record<string, string> = {
...TYPE,
...FORMATS,
...FEATURES,
...COMMUNITIES,
}
```

## Testing
✅ Verified all category badges display correctly
✅ Verified tooltips show correct descriptions
✅ Verified color coding by category type

## Impact
- 🧹 Removed duplicate code
- 🎯 Single source of truth for category definitions
- 📝 Improved type safety
- 🔄 Better maintainability

## Next Steps
A separate PR will address the category filtering functionality to align with the new category structure.