### PR TITLE
Add delay to text search, 300ms after last keystroke, Partially addresses #123

### DIFF
--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useState, useEffect } from "react"
 
 import type { WeekdayNumbers } from "luxon"
 import { DateTime } from "luxon"
@@ -35,6 +35,16 @@ export function Filter({
   sendQueryToParent,
 }: FilterProps) {
   const [searchQueryEntry, setSearchQueryEntry] = useState<string>("")
+
+  useEffect(() => {
+    const delayDebounce = setTimeout(() => {
+      if (searchQueryEntry.length > 2) {
+        sendQueryToParent(searchQueryEntry)
+      }
+    }, 300)
+
+    return () => clearTimeout(delayDebounce)
+  }, [searchQueryEntry])
 
   const timeFrames = {
     morning: { start: "04:00", end: "10:59", hours: 7 },
@@ -196,7 +206,6 @@ export function Filter({
 
   const handleInputChange = (value: string) => {
     setSearchQueryEntry(value)
-    if (value.length > 2) sendQueryToParent(value)
   }
 
   return (


### PR DESCRIPTION
```
useEffect(() => {
  const delayDebounce = setTimeout(() => {
    if (searchQueryEntry.length > 2) {
      sendQueryToParent(searchQueryEntry)
    }
  }, 300)

  return () => clearTimeout(delayDebounce)
}, [searchQueryEntry])
```

- Run a timer after every keystroke
- If another keystroke happens, cancel the old timer
- After 300ms of inactivity, call sendQueryToParent