### PR TITLE
Feature/remove client filtering

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@react-router/node": "^7.1.1",
         "isbot": "^5",
         "luxon": "^3.5.0",
-        "match-sorter": "^8.0.0",
         "next-themes": "^0.4.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -5513,16 +5512,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
-    "node_modules/match-sorter": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-8.0.0.tgz",
-      "integrity": "sha512-bGJ6Zb+OhzXe+ptP5d80OLVx7AkqfRbtGEh30vNSfjNwllu+hHI+tcbMIT/fbkx/FKN1PmKuDb65+Oofg+XUxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.8",
-        "remove-accents": "0.5.0"
-      }
-    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -6361,12 +6350,6 @@
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
       "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "license": "MIT"
-    },
-    "node_modules/remove-accents": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.5.0.tgz",
-      "integrity": "sha512-8g3/Otx1eJaVD12e31UbJj1YzdtVvzH85HV7t+9MJYk/u3XmkOUJ5Ys9wQrf9PCPK8+xn4ymzqYCiZl6QWKn+A==",
       "license": "MIT"
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@react-router/node": "^7.1.1",
     "isbot": "^5",
     "luxon": "^3.5.0",
-    "match-sorter": "^8.0.0",
     "next-themes": "^0.4.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/routes/meetings-filtered.tsx
+++ b/src/routes/meetings-filtered.tsx
@@ -1,39 +1,31 @@
 import { useState } from "react"
 
 import { DateTime } from "luxon"
-import {
-  Outlet,
-  useSearchParams,
-} from "react-router"
+import { Outlet, useSearchParams } from "react-router"
 
 import { Filter } from "@/components/Filter"
 import { Layout } from "@/components/Layout"
 import { MeetingsSummary } from "@/components/MeetingsSummary"
 import { getMeetings } from "@/getData"
-import {
-  applyMeetingFilters,
-  buildFilter,
-} from "@/utils/meetings-utils"
 import { Text } from "@chakra-ui/react"
 
 import type { Route } from "./+types/meetings-filtered"
 
+function buildMeetingsQueryString(searchParams: URLSearchParams): string {
+  if (![...searchParams.entries()].length) {
+    const params = new URLSearchParams({
+      start: DateTime.now().toUTC().toISO(),
+      hours: "1",
+    })
+    return `?${params.toString()}`
+  }
+  return `?${searchParams.toString()}`
+}
+
 export async function clientLoader({ request }: Route.ClientLoaderArgs) {
-  console.log(request)
   const { searchParams } = new URL(request.url)
-  const isSearchParamsEmpty = ![...searchParams.entries()].length
-
-  console.log("searchParams", searchParams)
-  const qs = isSearchParamsEmpty
-    ? `?start=${DateTime.now().toUTC().toISO()}&hours="1"`
-    : `?${searchParams.toString()}`
-  console.log("qs", qs)
-  const filter = buildFilter(searchParams)
-  const unfilteredMeetings = await getMeetings(qs)
-
-  const meetings = applyMeetingFilters(unfilteredMeetings, filter)
-  console.log(meetings)
-
+  const qs = buildMeetingsQueryString(searchParams)
+  const meetings = await getMeetings(qs)
   return { meetings }
 }
 

--- a/src/routes/meetings.test.ts
+++ b/src/routes/meetings.test.ts
@@ -1,12 +1,7 @@
-import {
-  expect,
-  test,
-} from "vitest"
+import { expect, test } from "vitest"
 
 import { getMeetings } from "@/getData"
 import type { Format } from "@/meetingTypes"
-
-import { buildFilter } from "../utils/meetings-utils"
 
 test("Retrieves an array of meetings", async () => {
   const result = await getMeetings()
@@ -42,54 +37,4 @@ test("Retrieves discussion meetings in Spanish", async () => {
 
   expect(results).toHaveLength(1)
   expect(results[0].name).toBe("Test Meeting 2")
-})
-
-test("Filter is correctly built", () => {
-  const { searchParams } = new URL(
-    new Request(
-      "http://localhost:5173/?languages=EN&languages=ES&communities=W"
-    ).url
-  )
-
-  expect(buildFilter(searchParams)).toStrictEqual({
-    languages: ["EN", "ES"],
-    communities: ["W"],
-  })
-})
-
-test("Empty search params returns empty filter", () => {
-  const { searchParams } = new URL(new Request("http://localhost:5173/").url)
-
-  expect(buildFilter(searchParams)).toStrictEqual({})
-})
-
-test("Single value params are returned as arrays", () => {
-  const { searchParams } = new URL(
-    new Request("http://localhost:5173/?communities=W").url
-  )
-
-  expect(buildFilter(searchParams)).toStrictEqual({
-    communities: ["W"],
-  })
-})
-
-test("Unknown params are not included in the filter", () => {
-  const { searchParams } = new URL(
-    new Request("http://localhost:5173/?unknown=test&communities=W").url
-  )
-  expect(buildFilter(searchParams)).toEqual({
-    communities: ["W"],
-  })
-})
-
-test("Multiple instances of same param are grouped", () => {
-  const { searchParams } = new URL(
-    new Request(
-      "http://localhost:5173/?communities=W&communities=X&communities=Y"
-    ).url
-  )
-
-  expect(buildFilter(searchParams)).toStrictEqual({
-    communities: ["W", "X", "Y"],
-  })
 })

--- a/src/utils/meetings-utils.ts
+++ b/src/utils/meetings-utils.ts
@@ -1,53 +1,3 @@
-import { matchSorter } from "match-sorter"
-
-import type { Community, Feature, Format, Meeting, Type } from "../meetingTypes"
-
-// TODO This can extend CategoryMap?
-export interface FilterParams {
-  nameQuery?: string
-  languages?: string[]
-  features?: Feature[]
-  formats?: Format[]
-  type?: Type
-  communities?: Community[]
-}
-
-export const fuzzyGlobalTextFilter = <T>(
-  rows: T[],
-  keys: string[],
-  filterValue: string | string[]
-): T[] => {
-  if (!filterValue) {
-    return rows
-  }
-
-  const filterValueStr = Array.isArray(filterValue)
-    ? filterValue.join(" ")
-    : filterValue
-  const terms = filterValueStr.split(" ")
-
-  return terms.reduceRight(
-    (results, term) => matchSorter(results, term, { keys }),
-    rows
-  )
-}
-
-export const filteredData = <T extends object>(
-  data: T[],
-  filterValues: string[],
-  key: "type" | "formats" | "features" | "communities" | "languages"
-): T[] => {
-  if (filterValues.length === 0) return data
-
-  return filterValues.reduceRight(
-    (results, filterValue) =>
-      matchSorter(results, filterValue, {
-        keys: [{ threshold: matchSorter.rankings.EQUAL, key }],
-      }),
-    data
-  )
-}
-
 /** ToDo: Fix error handling */
 export const fetchData = async <T>(url: string): Promise<T> => {
   try {
@@ -62,52 +12,7 @@ export const fetchData = async <T>(url: string): Promise<T> => {
   }
 }
 
-export const buildFilter = (
-  searchParams: URLSearchParams
-): Record<string, string[]> => {
-  const filter: Record<string, string[]> = {}
-
-  for (const [key] of searchParams.entries()) {
-    filter[key] = searchParams.getAll(key)
-  }
-  return filter
-}
-
 export const toggleArrayElement = <T>(array: T[], value: T): T[] => {
   const newArray = array.filter((x) => x !== value)
   return newArray.length === array.length ? [...newArray, value] : newArray
-}
-
-/**
- * Applies filters to a list of meetings based on the provided filter parameters.
- * @param meetings - The list of meetings to filter.
- * @param filter - The filter parameters to apply.
- * @returns The filtered list of meetings.
- */
-export const applyMeetingFilters = (
-  meetings: Meeting[],
-  filter: FilterParams
-): Meeting[] => {
-  const { nameQuery, features, formats, type, communities, languages } = filter
-  const applyFilters = [
-    type ? (data: Meeting[]) => filteredData(data, [type], "type") : undefined,
-    formats
-      ? (data: Meeting[]) => filteredData(data, formats, "formats")
-      : undefined,
-    features
-      ? (data: Meeting[]) => filteredData(data, features, "features")
-      : undefined,
-    communities
-      ? (data: Meeting[]) => filteredData(data, communities, "communities")
-      : undefined,
-    languages
-      ? (data: Meeting[]) => filteredData(data, languages, "languages")
-      : undefined,
-    nameQuery
-      ? (data: Meeting[]) =>
-          fuzzyGlobalTextFilter(data, ["name", "slug"], nameQuery)
-      : undefined,
-  ].filter(Boolean) as ((data: Meeting[]) => Meeting[])[]
-
-  return applyFilters.reduce((data, filterFn) => filterFn(data), meetings)
 }


### PR DESCRIPTION
This branch removes unused code that used to apply filters locally on the client.

This new approach instead simply passes the query string to `central-query`.

Closes  #18