### PR TITLE
Fix #29: Clear nameQuery param from URL when search field is empty

### DIFF
--- a/src/components/Filter.tsx
+++ b/src/components/Filter.tsx
@@ -1,4 +1,7 @@
-import { useState, useEffect } from "react"
+import {
+  useEffect,
+  useState,
+} from "react"
 
 import type { WeekdayNumbers } from "luxon"
 import { DateTime } from "luxon"
@@ -18,7 +21,14 @@ import {
   TYPE,
 } from "@/meetingTypes"
 import { toggleArrayElement } from "@/utils/meetings-utils"
-import { Box, Button, Flex, Heading, Text, VStack } from "@chakra-ui/react"
+import {
+  Box,
+  Button,
+  Flex,
+  Heading,
+  Text,
+  VStack,
+} from "@chakra-ui/react"
 
 import { CategoryFilter } from "./categoryFilter"
 import { SearchInput } from "./SearchInput"
@@ -34,6 +44,7 @@ export function Filter({
   sendFilterSelectionsToParent,
 }: FilterProps) {
   const [searchQueryEntry, setSearchQueryEntry] = useState<string>("")
+  const [showMinCharWarning, setShowMinCharWarning] = useState(false)
 
   useEffect(() => {
     const delayDebounce = setTimeout(() => {
@@ -46,7 +57,7 @@ export function Filter({
 
         if (query.length > 2) {
           next.set("nameQuery", query)
-        } else {
+        } else if (query.length == 0){
           next.delete("nameQuery")
         }
       return next
@@ -231,6 +242,7 @@ export function Filter({
 
   const handleInputChange = (value: string) => {
     setSearchQueryEntry(value)
+    setShowMinCharWarning(value.length > 0 && value.length < 3)
   }
 
   return (
@@ -293,7 +305,16 @@ export function Filter({
               })}
             </select>
           </Box>
-          <SearchInput value={searchQueryEntry} onChange={handleInputChange} />
+          <SearchInput
+            value={searchQueryEntry}
+            onChange={handleInputChange}
+            isInvalid={showMinCharWarning}
+          />
+          {showMinCharWarning && (
+            <Text fontSize="sm" color="red.500" mt={1}>
+              Enter at least 3 characters to search by name.
+            </Text>
+          )}
           <CategoryFilter<Type>
             displayName={"Meeting Type"}
             options={TYPE}

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -1,17 +1,22 @@
 import { FaSearch } from "react-icons/fa"
 
-import { Box, Input } from "@chakra-ui/react"
+import {
+  Box,
+  Input,
+} from "@chakra-ui/react"
 
 interface SearchInputProps {
   value: string
   onChange: (value: string) => void
   placeholder?: string
+  isInvalid?: boolean
 }
 
 export const SearchInput = ({
   value,
   onChange,
   placeholder = "Search meetings...",
+  isInvalid = false,
 }: SearchInputProps) => {
   return (
     <Box position="relative">
@@ -33,17 +38,17 @@ export const SearchInput = ({
         placeholder={placeholder}
         pl={10}
         variant="outline"
-        bg="white"
+        bg={isInvalid ? "red.100" : "white"}
         _dark={{
-          bg: "whiteAlpha.100",
-          borderColor: "whiteAlpha.300",
+          bg: isInvalid ? "red.300" : "whiteAlpha.100",
+          borderColor: isInvalid ? "red.500" : "whiteAlpha.300",
           color: "white",
           _hover: {
-            bg: "whiteAlpha.200",
+            bg: isInvalid ? "red.400" : "whiteAlpha.200",
           },
           _focus: {
-            bg: "whiteAlpha.300",
-            borderColor: "blue.300",
+            bg: isInvalid ? "red.400" : "whiteAlpha.300",
+            borderColor: isInvalid ? "red.500" : "blue.300",
           },
         }}
       />


### PR DESCRIPTION
Tweaked the filter component to handle the search field more intuitively when the input length is ≤ 2 characters.

In the version i committed
```
if (query.length > 2) {
  next.set("nameQuery", query)
} else {
  next.delete("nameQuery")
}
```

The nameQuery param is cleared anytime the input length drops to 2 characters or fewer. That means:
- If the user types a 3+ character search, the param is set.
- As soon as they delete characters and the input drops to 2 or fewer, the param is removed—even if the field still has 1–2 characters.

This feels a bit surprising because the search field still contains text, but the filter is effectively removed.

An alternate version:
```
if (query.length > 2) {
  next.set("nameQuery", query)
} else if (query.length === 0) {
  next.delete("nameQuery")
}
```

The param is only cleared when the search field is completely empty. So:
- Typing fewer than 3 characters keeps the previous filter "frozen" in the URL.
- The param remains visible (and active) even if the field only has 1–2 characters, which can also feel off—because what you see in the input no longer matches the filtering behavior.
