### PR TITLE
fix: improve Join Meeting button color in light mode 

### DIFF
--- a/src/components/meetings/MeetingActions.tsx
+++ b/src/components/meetings/MeetingActions.tsx
@@ -65,10 +65,18 @@ const JoinButton = ({
     size,
     minH: size === 'xs' ? '32px' : size === 'sm' ? '40px' : '44px',
     onClick: () => window.open(meeting.conference_url, '_blank', 'noopener,noreferrer'),
-    color: variant === 'solid' ? 'white' : 'blue.600',
-    _dark: { 
-      color: variant === 'solid' ? 'white' : 'blue.300' 
-    },
+    ...(variant === 'solid'
+      ? {
+          bg: 'blue.700',
+          color: 'white',
+          _hover: { bg: 'blue.800' },
+          _dark: { bg: 'blue.600', color: 'white', _hover: { bg: 'blue.700' } },
+        }
+      : {
+          color: 'blue.600',
+          _dark: { color: 'blue.300' },
+        }
+    ),
   }
 
   if (mode === 'icon-only') {


### PR DESCRIPTION
This PR updates the Join Meeting button styling in the meeting summary/list view to match the meeting details page.
- Uses explicit background, color, and hover styles for the solid variant in light mode , and appropriate dark mode overrides.
`([bg: blue.700](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), [color: white](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), [_hover: blue.800](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html))`
- Resolves the issue where the button appeared washed out in light mode due to Chakra UI’s default color scheme.
- No changes to button logic or layout—purely visual improvement for consistency and accessibility.

Testing:
- Verified in both light and dark modes.
- No regressions in button behavior or layout.
