### PR TITLE
remove calendar date from 'compact' and 'short' versions of MeetingTime

### DIFF
--- a/src/components/meetings/MeetingTime.tsx
+++ b/src/components/meetings/MeetingTime.tsx
@@ -158,7 +158,7 @@ export const MeetingTime = ({
       <Text {...primaryTextProps}>
         {!timeInfo.isSameTimezone && showLocal ? (
           <>
-            {timeInfo.userDate} {timeInfo.userTime}
+            {timeInfo.userDay} {timeInfo.userTime}
             {!timeInfo.isSameDay && (
               <Text as="span" {...secondaryTextProps} ml={1}>
                 (originally {timeInfo.originalDay})


### PR DESCRIPTION
To bring consistency between all meetings in all timezones, always display MeetingTime as 'Day' 'Time' in versions of MeetingTime used in list views for both mobile and desktop.
