### PR TITLE
fix: add explicit type annotation to async IIFE in clientLoader

### DIFF
--- a/src/routes/meetings-filtered.tsx
+++ b/src/routes/meetings-filtered.tsx
@@ -65,7 +65,7 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs): Promise
   }
   
   // Create and store promise immediately (before awaiting) to prevent race conditions
-  const promise = (async () => {
+  const promise: Promise<{ meetings: Meeting[] }> = (async () => {
     const meetings = await getMeetings(qs)
     const shuffled = shuffleWithinTimeSlots(meetings)
     const firstThree = shuffled.slice(0, 3).map(m => m.slug)


### PR DESCRIPTION
## Summary
- Adds explicit type annotation `Promise<{ meetings: Meeting[] }>` to the async IIFE in `clientLoader`
- Resolves `@typescript-eslint/no-unsafe-assignment` and `@typescript-eslint/no-unsafe-call` ESLint errors

## Test plan
- [x] Verify lint passes with `npm run lint`
- [ ] Confirm no type errors with `npm run typecheck`

🤖 Generated with [Claude Code](https://claude.com/claude-code)