### PR TITLE
fix: add dark mode text color support for WordPress plugin

### DIFF
--- a/src/components/filters/TimeFilter.tsx
+++ b/src/components/filters/TimeFilter.tsx
@@ -1,3 +1,5 @@
+import type React from "react"
+
 import { DateTime } from "luxon"
 
 import {
@@ -53,21 +55,28 @@ const SelectField = ({
   return (
     <Box>
       {showLabel && (
-        <Text fontSize="sm" fontWeight="medium" mb={2}>
+        <Text fontSize="sm" fontWeight="medium" mb={2} color="inherit">
           {label}:
         </Text>
       )}
-      <select
+      <Box
+        as="select"
         value={value}
-        onChange={(e) => {
+        onChange={(e: React.ChangeEvent<HTMLSelectElement>) => {
           onChange(e.target.value)
         }}
-        style={{
-          width: "100%",
-          padding: "8px",
-          border: "1px solid #E5E7EB",
-          borderRadius: "6px",
-          fontSize: "14px",
+        width="100%"
+        padding="8px"
+        border="1px solid"
+        borderColor="gray.200"
+        borderRadius="6px"
+        fontSize="14px"
+        bg="white"
+        color="gray.800"
+        _dark={{
+          borderColor: "gray.600",
+          bg: "gray.700",
+          color: "white",
         }}
       >
         {options.map((option) => (
@@ -90,7 +99,7 @@ const SelectField = ({
             })}
           </>
         )}
-      </select>
+      </Box>
     </Box>
   )
 }

--- a/src/components/meetings/MeetingsSummary.tsx
+++ b/src/components/meetings/MeetingsSummary.tsx
@@ -30,7 +30,13 @@ export function MeetingsSummary({
           <Heading size="lg">
             Meetings
             {
-              <Text as="span" fontSize="md" color="gray.500" ml={2}>
+              <Text
+                as="span"
+                fontSize="md"
+                color="gray.500"
+                _dark={{ color: "gray.400" }}
+                ml={2}
+              >
                 ({totalMeetings} total results; {meetings.length} shown.)
               </Text>
             }
@@ -48,7 +54,12 @@ export function MeetingsSummary({
               />
             ))}
             {meetings.length === 0 && (
-              <Text color="gray.500" textAlign="center" py={8}>
+              <Text
+                color="gray.500"
+                _dark={{ color: "gray.400" }}
+                textAlign="center"
+                py={8}
+              >
                 No meetings found matching your criteria
               </Text>
             )}

--- a/wordpress-plugin/assets/wordpress-overrides.css
+++ b/wordpress-plugin/assets/wordpress-overrides.css
@@ -301,16 +301,47 @@ body.admin-bar #oiaa-meetings-root {
 }
 
 /* ============================================================
-   DARK MODE SUPPORT
+   DARK MODE SUPPORT - Container-level text colors
    ============================================================ */
 
-/* Ensure dark mode works regardless of WordPress theme */
+/*
+ * Set explicit text colors at container level so components using
+ * color="inherit" will get the correct color for the current theme.
+ * This prevents WordPress theme colors from bleeding into the app.
+ */
+
+/* Light mode (default) */
+#oiaa-meetings-root {
+  color: #1a202c; /* Chakra gray.800 - standard body text */
+  color-scheme: light;
+}
+
+/* Dark mode - Chakra UI uses .dark class on html/body */
+.dark #oiaa-meetings-root,
+.chakra-ui-dark #oiaa-meetings-root,
+[data-theme="dark"] #oiaa-meetings-root,
+#oiaa-meetings-root.dark {
+  color: rgba(255, 255, 255, 0.92); /* Chakra's dark mode body text */
+  color-scheme: dark;
+}
+
+/* Also handle when data-theme is on the root itself */
 #oiaa-meetings-root[data-theme="dark"] {
-  color-scheme: dark !important;
+  color: rgba(255, 255, 255, 0.92);
+  color-scheme: dark;
 }
 
 #oiaa-meetings-root[data-theme="light"] {
-  color-scheme: light !important;
+  color: #1a202c;
+  color-scheme: light;
+}
+
+/* System preference fallback when no explicit theme is set */
+@media (prefers-color-scheme: dark) {
+  #oiaa-meetings-root:not([data-theme="light"]):not(.light) {
+    color: rgba(255, 255, 255, 0.92);
+    color-scheme: dark;
+  }
 }
 
 /* ============================================================


### PR DESCRIPTION
## Summary
Fixes dark mode text visibility in WordPress plugin by setting container-level text colors.

**Architectural approach:** Instead of fixing each component individually, we set explicit text colors on `#oiaa-meetings-root` that respond to dark mode. Components using `color="inherit"` now get the correct color regardless of WordPress theme.

## Changes
- **wordpress-overrides.css**: Add container-level light/dark text colors
  - Support `.dark`, `.chakra-ui-dark`, `[data-theme="dark"]` selectors
  - Add `prefers-color-scheme` media query fallback
- **MeetingsSummary.tsx**: Add `_dark` variant for gray.500 text
- **TimeFilter.tsx**: Convert select to Chakra Box with proper dark mode styling

## Test plan
- [ ] Build WordPress plugin with `npm run build:wordpress-plugin`
- [ ] Install in WordPress and verify text is visible in dark mode
- [ ] Check "Meetings" header, filter labels, and filter badges are readable
- [ ] Verify dropdowns have proper dark mode styling

**Note:** This PR targets `fix/wordpress-css-resets` (PR #67) as its base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)