### PR TITLE
add support for unschduled meetings in the shuffle logic

### DIFF
--- a/src/routes/meetings-filtered.tsx
+++ b/src/routes/meetings-filtered.tsx
@@ -11,7 +11,7 @@ import { Layout } from "@/components/Layout"
 import { MeetingsSummary } from "@/components/meetings"
 import { getMeetings } from "@/getData"
 import type { Meeting } from "@/meetingTypes"
-import { isScheduledMeeting, shuffleWithinTimeSlots } from "@/utils/meetings-utils"
+import { shuffleWithinTimeSlots } from "@/utils/meetings-utils"
 import {
   Box,
   Text,
@@ -67,9 +67,7 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs): Promise
   // Create and store promise immediately (before awaiting) to prevent race conditions
   const promise = (async () => {
     const meetings = await getMeetings(qs)
-    // Filter to only scheduled meetings (those with timeUTC) for shuffling
-    const scheduledMeetings = meetings.filter(isScheduledMeeting)
-    const shuffled = shuffleWithinTimeSlots(scheduledMeetings)
+    const shuffled = shuffleWithinTimeSlots(meetings)
     const firstThree = shuffled.slice(0, 3).map(m => m.slug)
     console.log(`🟢 #${callId} returning`, shuffled.length, 'meetings (shuffled). First 3:', firstThree)
     return { meetings: shuffled }

--- a/src/utils/meetings-utils.ts
+++ b/src/utils/meetings-utils.ts
@@ -55,14 +55,22 @@ const groupByTimeSlot = <T extends TimeSlotted>(items: T[]): T[][] => {
   }, [])
 }
 
-export const shuffleWithinTimeSlots = <T extends TimeSlotted>(
+export const shuffleWithinTimeSlots = <T extends Partial<TimeSlotted>>(
   items: T[]
 ): T[] => {
-
-  assertSortedByTimeUTC(items)
-
-  const timeSlotGroups = groupByTimeSlot(items)
-  return timeSlotGroups.flatMap(fisherYatesShuffle)
+  const scheduled = items.filter((item): item is T & TimeSlotted => Boolean(item.timeUTC))
+  const unscheduled = items.filter(item => !item.timeUTC)
+  
+  const shuffledUnscheduled = fisherYatesShuffle(unscheduled)
+  
+  let shuffledScheduled: T[] = []
+  if (scheduled.length > 0) {
+    assertSortedByTimeUTC(scheduled)
+    const timeSlotGroups = groupByTimeSlot(scheduled)
+    shuffledScheduled = timeSlotGroups.flatMap(fisherYatesShuffle)
+  }
+  
+  return [...shuffledUnscheduled, ...shuffledScheduled]
 }
 
 export const isScheduledMeeting = <T extends { timeUTC?: string; timezone?: string }>(


### PR DESCRIPTION
Follow-up to #69: Refactor shuffle logic to handle mixed meeting types

Enhanced `shuffleWithinTimeSlots()` to automatically handle both scheduled and unscheduled meetings:
- Unscheduled meetings are shuffled using Fisher-Yates and placed at the head of the list
- Scheduled meetings continue to be shuffled within their time slots
- Simplified the clientLoader by removing conditional shuffle logic

This consolidation makes the code more maintainable and guards against edge cases where meeting types might be mixed, rather than duplicating shuffle strategies in the loader.