### PR TITLE
refactor: replace inline styles with Chakra UI components

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -39,6 +39,9 @@ export function Layout({ children, sidebar }: LayoutProps) {
                     background: 'var(--chakra-colors-gray-300)',
                     borderRadius: '24px',
                   },
+                  '.dark &::-webkit-scrollbar-thumb': {
+                    background: 'var(--chakra-colors-gray-600)',
+                  },
                 }}
               >
                 {sidebar}

--- a/src/components/filters/TimeFilter.tsx
+++ b/src/components/filters/TimeFilter.tsx
@@ -35,6 +35,17 @@ const TIME_FRAME_OPTIONS = [
   { value: "night", label: "Night (9 PM-4 AM)" },
 ]
 
+// Styled select with Chakra-compatible theming
+const selectStyles = {
+  width: "100%",
+  padding: "8px 12px",
+  borderWidth: "1px",
+  borderStyle: "solid",
+  borderRadius: "6px",
+  fontSize: "14px",
+  cursor: "pointer",
+} as const
+
 const SelectField = ({
   label,
   value,
@@ -57,43 +68,48 @@ const SelectField = ({
           {label}:
         </Text>
       )}
-      <select
-        value={value}
-        onChange={(e) => {
-          onChange(e.target.value)
-        }}
-        style={{
-          width: "100%",
-          padding: "8px",
-          border: "1px solid",
-          borderColor: "var(--chakra-colors-gray-200)",
-          borderRadius: "6px",
-          fontSize: "14px",
-          backgroundColor: "var(--chakra-colors-chakra-body-bg)",
-          color: "var(--chakra-colors-chakra-body-text)",
+      <Box
+        borderWidth="1px"
+        borderColor="gray.200"
+        borderRadius="md"
+        bg="white"
+        _dark={{
+          bg: "gray.800",
+          borderColor: "gray.600",
         }}
       >
-        {options.map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-        {includeHourlyOptions && (
-          <>
-            <option disabled>──────────</option>
-            {Array.from({ length: 24 }).map((_, hour) => {
-              const dt = DateTime.fromObject({ hour, minute: 0 })
-              const label = dt.toLocaleString(DateTime.TIME_SIMPLE)
-              const value = dt.toFormat("HH:mm")
-              return (
-                <option value={value} key={value}>
-                  {label}
-                </option>
-              )
-            })}
-          </>
-        )}
-      </select>
+        <select
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          style={{
+            ...selectStyles,
+            border: "none",
+            background: "transparent",
+            color: "inherit",
+          }}
+        >
+          {options.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+          {includeHourlyOptions && (
+            <>
+              <option disabled>──────────</option>
+              {Array.from({ length: 24 }).map((_, hour) => {
+                const dt = DateTime.fromObject({ hour, minute: 0 })
+                const optionLabel = dt.toLocaleString(DateTime.TIME_SIMPLE)
+                const optionValue = dt.toFormat("HH:mm")
+                return (
+                  <option value={optionValue} key={optionValue}>
+                    {optionLabel}
+                  </option>
+                )
+              })}
+            </>
+          )}
+        </select>
+      </Box>
     </Box>
   )
 }

--- a/src/components/meetings/MeetingActions.tsx
+++ b/src/components/meetings/MeetingActions.tsx
@@ -9,6 +9,7 @@ import { Tooltip } from "@/components/ui/tooltip"
 import type { Meeting } from "@/meetingTypes"
 import { getServiceProviderNameFromUrl } from "@/utils/videoServices"
 import {
+  Box,
   Button,
   Flex,
   IconButton,
@@ -96,7 +97,9 @@ const JoinButton = ({
   
   return (
     <Button {...buttonProps}>
-      <IconComponent style={{ marginRight: mode === 'compact' ? '4px' : '8px' }} />
+      <Box as="span" mr={mode === 'compact' ? 1 : 2} display="inline-flex">
+        <IconComponent />
+      </Box>
       {label}
     </Button>
   )
@@ -143,7 +146,9 @@ const EmailButton = ({
 
   return (
     <Button {...buttonProps}>
-      <FaEnvelope style={{ marginRight: mode === 'compact' ? '4px' : '8px' }} />
+      <Box as="span" mr={mode === 'compact' ? 1 : 2} display="inline-flex">
+        <FaEnvelope />
+      </Box>
       {label}
     </Button>
   )
@@ -189,7 +194,9 @@ const WebsiteButton = ({
 
   return (
     <Button {...buttonProps}>
-      <FaLink style={{ marginRight: mode === 'compact' ? '4px' : '8px' }} />
+      <Box as="span" mr={mode === 'compact' ? 1 : 2} display="inline-flex">
+        <FaLink />
+      </Box>
       {label}
     </Button>
   )

--- a/src/components/meetings/MeetingCategories.tsx
+++ b/src/components/meetings/MeetingCategories.tsx
@@ -209,8 +209,11 @@ export const MeetingCategories = ({
             background: 'transparent',
           },
           '&::-webkit-scrollbar-thumb': {
-            background: '#CBD5E0',
+            background: 'var(--chakra-colors-gray-300)',
             borderRadius: '4px',
+          },
+          '.dark &::-webkit-scrollbar-thumb': {
+            background: 'var(--chakra-colors-gray-600)',
           },
         }}
       >

--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,12 @@
+/*
+ * Minimal global styles - Chakra UI handles component styling
+ * This file only contains essential resets and theme-based colors
+ */
+
 :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -13,56 +14,35 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+/* Light mode (default) */
+:root,
+.light {
+  color-scheme: light;
+  color: #213547;
+  background-color: #ffffff;
 }
 
+/* Dark mode - applied via class by next-themes */
+.dark {
+  color-scheme: dark;
+  color: rgba(255, 255, 255, 0.87);
+  background-color: #242424;
+}
+
+/* Minimal body reset */
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
+/* Minimal button reset - let Chakra UI handle all button styling */
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
   cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+button:focus-visible {
+  outline: 2px solid #3182ce;
+  outline-offset: 2px;
 }

--- a/src/routes/meetings-filtered.tsx
+++ b/src/routes/meetings-filtered.tsx
@@ -14,6 +14,8 @@ import type { Meeting } from "@/meetingTypes"
 import { shuffleWithinTimeSlots } from "@/utils/meetings-utils"
 import {
   Box,
+  Button,
+  Flex,
   Text,
   useBreakpointValue,
 } from "@chakra-ui/react"
@@ -131,47 +133,26 @@ export default function MeetingsFiltered({ loaderData }: Route.ComponentProps) {
   }
 
   const PaginationButtons = () => (
-    <div
-      style={{
-        display: "flex",
-        justifyContent: "center",
-        marginTop: "16px",
-        marginBottom: "16px",
-      }}
-    >
-      <button
+    <Flex justify="center" my={4} gap={2}>
+      <Button
         onClick={handlePreviousPage}
         disabled={currentPage === 0}
-        style={{
-          marginRight: "8px",
-          padding: "8px 16px",
-          backgroundColor: "#3182ce",
-          color: "white",
-          border: "none",
-          borderRadius: "4px",
-          cursor: currentPage === 0 ? "not-allowed" : "pointer",
-        }}
+        colorScheme="blue"
+        size="md"
+        _disabled={{ opacity: 0.6, cursor: "not-allowed" }}
       >
         Previous
-      </button>
-      <button
+      </Button>
+      <Button
         onClick={handleNextPage}
         disabled={(currentPage + 1) * meetingsPerPage >= meetings.length}
-        style={{
-          padding: "8px 16px",
-          backgroundColor: "#3182ce",
-          color: "white",
-          border: "none",
-          borderRadius: "4px",
-          cursor:
-            (currentPage + 1) * meetingsPerPage >= meetings.length
-              ? "not-allowed"
-              : "pointer",
-        }}
+        colorScheme="blue"
+        size="md"
+        _disabled={{ opacity: 0.6, cursor: "not-allowed" }}
       >
         Next
-      </button>
-    </div>
+      </Button>
+    </Flex>
   )
 
   return (


### PR DESCRIPTION
## Summary

Refactors inline styles throughout the codebase to use proper Chakra UI components and theme tokens, improving maintainability and dark mode support.

## Changes

### HIGH PRIORITY - Pagination Buttons (`meetings-filtered.tsx`)
- Replaced raw `<button>` elements with Chakra `<Button>` component
- Replaced `<div style={{}}>` with Chakra `<Flex>`
- Changed from `#3182ce` → `colorScheme="blue"`
- Changed from hardcoded `16px`/`8px` → Chakra spacing tokens (`my={4}`, `gap={2}`)
- Added proper disabled state styling with `_disabled`

### MEDIUM PRIORITY - Icon Spacing (`MeetingActions.tsx`)
- Replaced inline `style={{ marginRight: '4px' }}` → Chakra `<Box mr={1}>`
- Uses Chakra spacing scale (1 = 4px, 2 = 8px)

### MEDIUM PRIORITY - Scrollbar Styling
- `MeetingCategories.tsx`: Changed `#CBD5E0` → `var(--chakra-colors-gray-300)`
- `Layout.tsx`: Added dark mode scrollbar support
- Both now use CSS variables for theme-aware colors

### MEDIUM PRIORITY - Select Styling (`TimeFilter.tsx`)
- Wrapped native `<select>` in Chakra `<Box>` with theme-aware border/background
- Added proper dark mode support with `_dark` props

### LOW PRIORITY - Global CSS (`index.css`)
- Removed conflicting button/link/heading styles
- Minimized to essential resets only
- Chakra UI now handles all component styling

## Before/After

| Component | Before | After |
|-----------|--------|-------|
| Pagination | `style={{ backgroundColor: "#3182ce" }}` | `colorScheme="blue"` |
| Icon margins | `style={{ marginRight: '8px' }}` | `<Box mr={2}>` |
| Scrollbar | `background: '#CBD5E0'` | `var(--chakra-colors-gray-300)` |

## Test plan

- [x] Typecheck passes
- [x] WordPress plugin builds successfully
- [ ] Verify pagination buttons render correctly in light/dark mode
- [ ] Verify filter selects work properly
- [ ] Verify action buttons display icons correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)