### PR TITLE
chore: rename build script to build:react-router

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ OIAA Direct is a React + TypeScript + Vite application for browsing online AA me
 ```bash
 npm run dev          # Start development server (react-router dev)
 npm run typecheck    # Generate route types + TypeScript check
-npm run build        # TypeScript build + react-router build
+npm run build:react-router  # TypeScript build + react-router build
 npm test             # Run Vitest tests
 npm run lint         # ESLint
 npm test -- --run src/utils/someFile.test.ts  # Run a single test file

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "react-router dev",
     "typecheck": "react-router typegen && tsc -b",
-    "build": "tsc -b && react-router build",
+    "build:react-router": "tsc -b && react-router build",
     "build:wordpress": "vite build --config vite.config-wordpress.ts",
     "build:wordpress-plugin": "node scripts/build-wordpress-plugin.js",
     "test": "vitest",


### PR DESCRIPTION
for consistency
fixes #59

I'm not totally sure that issue was intentionally created but it seemed like a good way to get my feet wet in this repo : ) 

This does mean that we can't use the `build` command anymore, so if it's used somewhere like a production deployment process that will break with `npm error Missing script: "build"` unless we update it.

