### PR TITLE
Show global loading bar; parallelize data fetch

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,3 +1,4 @@
+import { useNavigation } from "react-router"
 import {
   Box,
   Container,
@@ -10,8 +11,29 @@ interface LayoutProps {
 }
 
 export function Layout({ children, sidebar }: LayoutProps) {
+  const navigation = useNavigation()
+  const isLoading = navigation.state === "loading"
+
   return (
     <Box width="100%" display="flex" justifyContent="center" minH="100vh">
+      {isLoading && (
+        <Box
+          position="fixed"
+          top={0}
+          left={0}
+          right={0}
+          height="2px"
+          bg="blue.500"
+          zIndex={9999}
+          animation="pulse 1.5s ease-in-out infinite"
+          css={{
+            "@keyframes pulse": {
+              "0%, 100%": { opacity: 1 },
+              "50%": { opacity: 0.5 },
+            },
+          }}
+        />
+      )}
       <Container maxW="7xl" mx="auto" px={{ base: 4, md: 8 }} width="100%">
         <Box maxW="1200px" mx="auto" width="100%" position="relative">
           <Grid

--- a/src/routes/group-info.tsx
+++ b/src/routes/group-info.tsx
@@ -235,10 +235,10 @@ const MeetingHeader = ({ meeting }: { meeting: Meeting }) => {
 }
 
 export async function clientLoader({ params }: Route.ClientLoaderArgs) {
-  const meeting = await getMeeting(params.slug)
-  const group = await getRelatedDetails(`${params.slug}/related-group-info`)
-  console.log("meeting", meeting)
-  console.log("group", group)
+  const [meeting, group] = await Promise.all([
+    getMeeting(params.slug),
+    getRelatedDetails(`${params.slug}/related-group-info`)
+  ])
   return { meeting, group }
 }
 


### PR DESCRIPTION
1. Add a top fixed 2px animated loading bar in Layout using useNavigation when navigation.state === "loading" to provide visual feedback during route changes.
2. In group-info loader, replace sequential awaits with Promise.all to fetch meeting and related group info in parallel and remove debug console.logs, improving load performance.