### PR TITLE
Convert WordPress plugin to use createBrowserRouter

### DIFF
--- a/src/entry-wordpress.tsx
+++ b/src/entry-wordpress.tsx
@@ -1,12 +1,12 @@
 // @ts-nocheck
 // TypeScript checking disabled for WordPress entry point
-// This file uses hash router which has different type signatures than React Router v7's data router
+// This file uses createBrowserRouter with runtime basename which differs from React Router v7's build-time routing
 
 import "./index.css"
 
 import React from "react"
 import ReactDOM from "react-dom/client"
-import { createHashRouter, RouterProvider, useLoaderData } from "react-router"
+import { createBrowserRouter, RouterProvider, useLoaderData } from "react-router"
 
 import { Provider } from "@/components/ui/provider"
 import MeetingsFiltered, { clientLoader as meetingsClientLoader } from "@/routes/meetings-filtered"
@@ -18,6 +18,7 @@ declare global {
     OIAA_CONFIG?: {
       apiUrl?: string
       colorMode?: "light" | "dark" | "system"
+      basePath?: string
     }
   }
 }
@@ -45,25 +46,31 @@ function GroupInfoWrapper() {
   return <GroupInfo loaderData={loaderData} />
 }
 
-// Create hash-based router with same routes as standard build
-const router = createHashRouter([
+// Get base path from WordPress config (e.g., "/meetings" or "/" for homepage)
+// Default to "/meetings" if not configured
+const basePath = window.OIAA_CONFIG?.basePath || "/meetings"
+
+// Create browser-based router with basename support
+const router = createBrowserRouter([
   {
     path: "/",
     element: <MeetingsFilteredWrapper />,
     loader: async ({ request }) => {
-      // Adapt clientLoader to work with hash router's loader signature
+      // Adapt clientLoader to work with browser router's loader signature
       return meetingsClientLoader({ request, params: {}, serverLoader: async () => undefined })
     },
   },
   {
     path: "/group-info/:slug",
     element: <GroupInfoWrapper />,
-    loader: async ({ params }) => {
-      // Adapt clientLoader to work with hash router's loader signature
-      return groupInfoClientLoader({ request: new Request('/'), params: params, serverLoader: async () => undefined })
+    loader: async ({ params, request }) => {
+      // Adapt clientLoader to work with browser router's loader signature
+      return groupInfoClientLoader({ request, params: params, serverLoader: async () => undefined })
     },
   },
-])
+], {
+  basename: basePath,
+})
 
 /**
  * Initialize the OIAA Meetings app in WordPress

--- a/wordpress-plugin/includes/settings.php
+++ b/wordpress-plugin/includes/settings.php
@@ -38,6 +38,12 @@ function oiaa_meetings_settings_init() {
         'default' => 'system'
     ));
 
+    register_setting('oiaa_meetings', 'oiaa_base_path', array(
+        'type' => 'string',
+        'sanitize_callback' => 'oiaa_meetings_sanitize_base_path',
+        'default' => '/meetings'
+    ));
+
     add_settings_section(
         'oiaa_meetings_section',
         __('API Configuration', 'oiaa-meetings'),
@@ -66,6 +72,21 @@ function oiaa_meetings_settings_init() {
         'oiaa_meetings_color_mode_render',
         'oiaa_meetings',
         'oiaa_meetings_appearance_section'
+    );
+
+    add_settings_section(
+        'oiaa_meetings_routing_section',
+        __('Routing Configuration', 'oiaa-meetings'),
+        'oiaa_meetings_routing_section_callback',
+        'oiaa_meetings'
+    );
+
+    add_settings_field(
+        'oiaa_base_path',
+        __('Base Path', 'oiaa-meetings'),
+        'oiaa_meetings_base_path_render',
+        'oiaa_meetings',
+        'oiaa_meetings_routing_section'
     );
 }
 add_action('admin_init', 'oiaa_meetings_settings_init');
@@ -104,11 +125,43 @@ function oiaa_meetings_appearance_section_callback() {
 }
 
 /**
+ * Routing settings section description
+ */
+function oiaa_meetings_routing_section_callback() {
+    echo __('Configure URL routing for the meetings application. This must match the WordPress page where you placed the [oiaa_meetings] shortcode.', 'oiaa-meetings');
+}
+
+/**
  * Sanitize color mode input
  */
 function oiaa_meetings_sanitize_color_mode($input) {
     $valid_modes = array('light', 'dark', 'system');
     return in_array($input, $valid_modes, true) ? $input : 'system';
+}
+
+/**
+ * Sanitize base path input
+ */
+function oiaa_meetings_sanitize_base_path($input) {
+    // Trim whitespace
+    $input = trim($input);
+    
+    // Ensure it starts with a slash
+    if (!empty($input) && $input[0] !== '/') {
+        $input = '/' . $input;
+    }
+    
+    // Remove trailing slash unless it's just "/"
+    if (strlen($input) > 1 && substr($input, -1) === '/') {
+        $input = rtrim($input, '/');
+    }
+    
+    // Default to /meetings if empty
+    if (empty($input)) {
+        $input = '/meetings';
+    }
+    
+    return $input;
 }
 
 /**
@@ -135,6 +188,29 @@ function oiaa_meetings_color_mode_render() {
 }
 
 /**
+ * Render base path input field
+ */
+function oiaa_meetings_base_path_render() {
+    $value = get_option('oiaa_base_path', '/meetings');
+    ?>
+    <input
+        type="text"
+        name="oiaa_base_path"
+        value="<?php echo esc_attr($value); ?>"
+        class="regular-text"
+        placeholder="/meetings"
+        required
+    />
+    <p class="description">
+        <?php _e('The URL path where the [oiaa_meetings] page is located. Must be a page slug matching the WordPress permalink structure. For example, if your page is at <code>https://yoursite.com/meetings</code>, enter <code>/meetings</code>. For the homepage, enter <code>/</code>.', 'oiaa-meetings'); ?>
+    </p>
+    <p class="description" style="color: #d63638;">
+        <strong><?php _e('Important:', 'oiaa-meetings'); ?></strong> <?php _e('The page slug must exactly match this setting. After changing this value, visit Settings → Permalinks and click "Save Changes" to flush rewrite rules.', 'oiaa-meetings'); ?>
+    </p>
+    <?php
+}
+
+/**
  * Render settings page
  */
 function oiaa_meetings_options_page() {
@@ -151,12 +227,17 @@ function oiaa_meetings_options_page() {
 
         <hr />
 
-        <h2><?php _e('Usage', 'oiaa-meetings'); ?></h2>
-        <p><?php _e('Add the following shortcode to any page or post where you want to display the OIAA Meetings application:', 'oiaa-meetings'); ?></p>
-        <code>[oiaa_meetings]</code>
-
-        <h3><?php _e('Example', 'oiaa-meetings'); ?></h3>
-        <p><?php _e('Create a new page and add this shortcode to the content area. The meetings application will render at that location.', 'oiaa-meetings'); ?></p>
+        <h2><?php _e('Setup Instructions', 'oiaa-meetings'); ?></h2>
+        <ol>
+            <li><?php _e('Ensure WordPress is using the "Post name" permalink structure (Settings → Permalinks)', 'oiaa-meetings'); ?></li>
+            <li><?php _e('Create a page with a slug matching your base path setting (e.g., "meetings").', 'oiaa-meetings'); ?></li>
+            <li><?php _e('Edit the page and add the shortcode to it:', 'oiaa-meetings'); ?></li>
+            <li style="margin-left: 2em; margin-top: 0.5em;"><code>[oiaa_meetings]</code></li>
+            <li style="margin-top: 0.5em;"><?php _e('Publish the page.', 'oiaa-meetings'); ?></li>
+            <li><?php _e('Configure the base path setting above to match your page slug.', 'oiaa-meetings'); ?></li>
+            <li><?php _e('Visit Settings → Permalinks and click "Save Changes" to flush rewrite rules.', 'oiaa-meetings'); ?></li>
+            <li><?php _e('All sub-routes (e.g., /meetings/group-info/slug) will now be served by your page.', 'oiaa-meetings'); ?></li>
+        </ol>
 
         <h3><?php _e('Plugin Information', 'oiaa-meetings'); ?></h3>
         <ul>

--- a/wordpress-plugin/includes/shortcode.php
+++ b/wordpress-plugin/includes/shortcode.php
@@ -28,6 +28,9 @@ function oiaa_meetings_shortcode($atts) {
     // Get color mode from settings
     $color_mode = get_option('oiaa_color_mode', 'system');
 
+    // Get base path from settings
+    $base_path = get_option('oiaa_base_path', '/meetings');
+
     // Output the container and configuration
     ob_start();
     ?>
@@ -35,7 +38,8 @@ function oiaa_meetings_shortcode($atts) {
     <script>
         window.OIAA_CONFIG = {
             apiUrl: <?php echo wp_json_encode($api_url); ?>,
-            colorMode: <?php echo wp_json_encode($color_mode); ?>
+            colorMode: <?php echo wp_json_encode($color_mode); ?>,
+            basePath: <?php echo wp_json_encode($base_path); ?>
         };
     </script>
     <?php

--- a/wordpress-plugin/oiaa-meetings-plugin.php
+++ b/wordpress-plugin/oiaa-meetings-plugin.php
@@ -30,8 +30,36 @@ function oiaa_meetings_init() {
     require_once OIAA_MEETINGS_PLUGIN_DIR . 'includes/settings.php';
     require_once OIAA_MEETINGS_PLUGIN_DIR . 'includes/shortcode.php';
     require_once OIAA_MEETINGS_PLUGIN_DIR . 'includes/enqueue.php';
+    
+    // Add rewrite rules for React Router
+    add_action('init', 'oiaa_meetings_add_rewrite_rules');
 }
 add_action('plugins_loaded', 'oiaa_meetings_init');
+
+/**
+ * Add rewrite rules to support React Router browser history
+ * Routes are derived from the configured base path (which must be a page slug)
+ */
+function oiaa_meetings_add_rewrite_rules() {
+    $base_path = get_option('oiaa_base_path', '/meetings');
+    
+    // Remove leading slash to get the page slug
+    $page_slug = ltrim($base_path, '/');
+    
+    // Skip rewrite rules for homepage (no need to rewrite to /)
+    if (empty($page_slug)) {
+        return;
+    }
+    
+    // Add simple rewrite rule that routes all sub-paths to the base page
+    // Matches /meetings, /meetings/, /meetings/group-info/slug, etc.
+    // and rewrites to the WordPress page with that slug
+    add_rewrite_rule(
+        '^' . preg_quote($page_slug, '/') . '(/.*)?$',
+        'index.php?pagename=' . $page_slug,
+        'top'
+    );
+}
 
 /**
  * Activation hook
@@ -41,6 +69,13 @@ function oiaa_meetings_activate() {
     if (get_option('oiaa_api_url') === false) {
         add_option('oiaa_api_url', 'https://central-query.apps.code4recovery.org/api/v1/meetings');
     }
+    
+    if (get_option('oiaa_base_path') === false) {
+        add_option('oiaa_base_path', '/meetings');
+    }
+    
+    // Flush rewrite rules to add our custom rules
+    flush_rewrite_rules();
 }
 register_activation_hook(__FILE__, 'oiaa_meetings_activate');
 
@@ -48,7 +83,8 @@ register_activation_hook(__FILE__, 'oiaa_meetings_activate');
  * Deactivation hook
  */
 function oiaa_meetings_deactivate() {
-    // Cleanup if needed
+    // Flush rewrite rules to remove our custom rules
+    flush_rewrite_rules();
 }
 register_deactivation_hook(__FILE__, 'oiaa_meetings_deactivate');
 
@@ -58,5 +94,7 @@ register_deactivation_hook(__FILE__, 'oiaa_meetings_deactivate');
 function oiaa_meetings_uninstall() {
     // Remove options
     delete_option('oiaa_api_url');
+    delete_option('oiaa_base_path');
+    delete_option('oiaa_color_mode');
 }
 register_uninstall_hook(__FILE__, 'oiaa_meetings_uninstall');


### PR DESCRIPTION
## Overview
Converts the WordPress plugin from hash router to browser router, enabling clean URLs instead of hash-based routing.

## Changes
- **React Router**: Updated `src/entry-wordpress.tsx` to use `createBrowserRouter` with `basename` support
- **Configuration**: Added `oiaa_base_path` setting to admin panel (defaults to `/meetings`, supports `/` for homepage)
- **Rewrite Rules**: Simplified to use WordPress's native `pagename` query var based on page slug

## How It Works
1. User creates a WordPress page with slug matching the base path (e.g., `meetings`)
2. User configures base path in plugin settings (e.g., `/meetings`)
3. Plugin generates rewrite rule: `/meetings(/.*)?` → `index.php?pagename=meetings`
4. WordPress resolves to the correct page, React Router handles client-side routing
5. All sub-routes (e.g., `/meetings/group-info/slug`) automatically served by the page

## Requirements
- WordPress must use "Post name" permalink structure (standard setting)
- Page slug must exactly match the configured base path

## Benefits
- ✅ Clean URLs without hash routing
- ✅ SEO-friendly
- ✅ Lightweight implementation (minimal dependencies)
- ✅ Follows WordPress best practices
- ✅ Supports homepage installation (set base path to `/`)