### PR TITLE
Add local WordPress dev setup with JointsWP theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ wordpress-plugin/assets/
 !wordpress-plugin/assets/wordpress-overrides.css
 *.zip
 
+# Third-party WordPress theme (cloned locally for dev)
+JointsWP/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/README.md
+++ b/README.md
@@ -36,6 +36,30 @@ VITE_CQ_URL="https://central-query.apps.code4recovery.org/api/v1/meetings"
 
 ---
 
+## WordPress Plugin Development
+
+To test the WordPress plugin locally in an environment that matches production:
+
+```bash
+# Start WordPress + MySQL
+docker-compose up -d
+
+# Clone the JointsWP theme (same theme used on aa-intergroup.org)
+git clone https://github.com/JeremyEnglert/JointsWP.git
+```
+
+Then:
+1. Visit http://localhost:8080/wp-admin (user: auto-created on first visit)
+2. Activate the JointsWP theme under Appearance → Themes
+3. The oiaa-meetings plugin is auto-mounted — activate it under Plugins
+
+After making changes to the plugin, rebuild with:
+```bash
+npm run build:wordpress-plugin
+```
+
+---
+
 ## Recommended VS Code Extensions
 
 - [Prettier - Code formatter](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+services:
+  db:
+    image: mysql:8.0
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: wordpress
+      MYSQL_DATABASE: wordpress
+      MYSQL_USER: wordpress
+      MYSQL_PASSWORD: wordpress
+    volumes:
+      - db_data:/var/lib/mysql
+
+  wordpress:
+    image: wordpress:latest
+    restart: unless-stopped
+    depends_on:
+      - db
+    ports:
+      - "8080:80"
+    environment:
+      WORDPRESS_DB_HOST: db
+      WORDPRESS_DB_USER: wordpress
+      WORDPRESS_DB_PASSWORD: wordpress
+      WORDPRESS_DB_NAME: wordpress
+    volumes:
+      - wp_data:/var/www/html
+      - ./wordpress-plugin:/var/www/html/wp-content/plugins/oiaa-meetings
+      - ./JointsWP:/var/www/html/wp-content/themes/JointsWP
+
+volumes:
+  db_data:
+  wp_data:


### PR DESCRIPTION
## Summary

- Adds `docker-compose.yml` with WordPress + MySQL to test the plugin locally
- Mounts JointsWP theme (same theme used on aa-intergroup.org and beta.aa-intergroup.org)
- Adds setup instructions to README
- Gitignores the cloned JointsWP directory

This enables developers to reproduce UI bugs that only appear with the production theme (e.g. #92, #93, #94, #95).

Closes #96

## Test plan

- [x] Run `docker-compose up -d` and verify WordPress starts at localhost:8080
- [x] Clone JointsWP and verify it appears in Appearance → Themes
- [x] Activate JointsWP and confirm the oiaa-meetings plugin renders correctly
- [x] Verify theme-specific bugs (#94, #95) are reproducible locally