### PR TITLE
fix: Remove redundant empty tooltip from category filter buttons

### DIFF
--- a/src/components/filters/CategoryFilter.tsx
+++ b/src/components/filters/CategoryFilter.tsx
@@ -1,4 +1,3 @@
-import { Tooltip } from "@/components/ui/tooltip"
 import { Box, Button, Flex, Heading } from "@chakra-ui/react"
 
 const CATEGORY_COLORS = {
@@ -39,38 +38,36 @@ export function CategoryFilter<T extends string>({
           const isSelected = selected.includes(code)
           return (
             <Box key={code}>
-              <Tooltip content={options[code]}>
-                <Button
-                  size="xs"
-                  variant="outline"
-                  colorScheme={isSelected ? colorScheme : "gray"}
-                  onClick={() => {
-                    onToggle(code)
-                  }}
-                  fontWeight="normal"
-                  px={3}
-                  height="24px"
-                  borderRadius="full"
-                  borderWidth="1px"
-                  color="inherit"
-                  bg={isSelected ? `${colorScheme}.100` : "transparent"}
-                  borderColor={isSelected ? `${colorScheme}.200` : "gray.200"}
-                  _dark={{
-                    borderColor: isSelected ? `${colorScheme}.800` : "gray.400",
-                    bg: isSelected ? `${colorScheme}.900` : "transparent",
-                    _hover: {
-                      bg: isSelected ? `${colorScheme}.800` : "whiteAlpha.100",
-                      borderColor: isSelected ? `${colorScheme}.300` : "whiteAlpha.500",
-                    },
-                  }}
-                  _hover={{
-                    bg: isSelected ? `${colorScheme}.200` : "gray.50",
-                    borderColor: isSelected ? `${colorScheme}.300` : "gray.300",
-                  }}
-                >
-                  {options[code]}
-                </Button>
-              </Tooltip>
+              <Button
+                size="xs"
+                variant="outline"
+                colorScheme={isSelected ? colorScheme : "gray"}
+                onClick={() => {
+                  onToggle(code)
+                }}
+                fontWeight="normal"
+                px={3}
+                height="24px"
+                borderRadius="full"
+                borderWidth="1px"
+                color="inherit"
+                bg={isSelected ? `${colorScheme}.100` : "transparent"}
+                borderColor={isSelected ? `${colorScheme}.200` : "gray.200"}
+                _dark={{
+                  borderColor: isSelected ? `${colorScheme}.800` : "gray.400",
+                  bg: isSelected ? `${colorScheme}.900` : "transparent",
+                  _hover: {
+                    bg: isSelected ? `${colorScheme}.800` : "whiteAlpha.100",
+                    borderColor: isSelected ? `${colorScheme}.300` : "whiteAlpha.500",
+                  },
+                }}
+                _hover={{
+                  bg: isSelected ? `${colorScheme}.200` : "gray.50",
+                  borderColor: isSelected ? `${colorScheme}.300` : "gray.300",
+                }}
+              >
+                {options[code]}
+              </Button>
             </Box>
           )
         })}


### PR DESCRIPTION
## Summary

Hovering over a category filter button (e.g. "Step Study") rendered an empty black tooltip box. The `Tooltip` wrapping each button used `content={options[code]}` — the exact same value as the button label — so it added no information even when it did render, and showed as an empty box under the JointsWP/Foundation styling on beta and prod.

Per the recommendation on the issue (tooltip text identical to button text → no value → removal candidate), this drops the redundant `Tooltip` wrapper from the filter buttons.

## Changes

- Remove `Tooltip` import and wrapper in `src/components/filters/CategoryFilter.tsx`; the `Button` (with its label) is now rendered directly.

The shared `Tooltip` component (`src/components/ui/tooltip.tsx`) is untouched — it's still used by `MeetingActions.tsx`.

## Testing

- `npm run typecheck` — no new errors (one pre-existing unrelated error in `CalendarActions.tsx` on main)
- `npm run lint` — no new findings for the changed file
- Manual: filter buttons no longer show an empty box on hover

Fixes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)
