### PR TITLE
fix: Restore icon button padding under JointsWP theme

### DIFF
--- a/wordpress-plugin/assets/wordpress-overrides.css
+++ b/wordpress-plugin/assets/wordpress-overrides.css
@@ -209,6 +209,19 @@
   color: white;
 }
 
+/* Restore horizontal padding on icon buttons (#94).
+   JointsWP/Foundation ships an unlayered `button { padding: 0 }` rule.
+   Chakra v3 emits its button padding inside a CSS @layer, and layered
+   styles always lose to unlayered ones regardless of specificity, so the
+   theme zeroes the padding on the Join/Email/Website action buttons. With
+   no inline padding the leading camera/link icon sits flush against the
+   button's rounded edge and its corner pokes out ("the button doesn't
+   fully cover the icon"). Re-inset the icon by restoring the padding. */
+#oiaa-meetings-root button:has(svg) {
+  padding-left: 0.75rem !important;
+  padding-right: 0.75rem !important;
+}
+
 /* ============================================================
    LIST RESET
    ============================================================ */


### PR DESCRIPTION
## Summary

The "Join Zoom" (and Email/Website) action buttons render with their leading icon flush against the button's rounded left edge, so the icon's corner pokes past the rounded corner — the button appears not to fully cover the icon. Only reproduces under the JointsWP theme used on beta/prod.

## Root cause

JointsWP/Foundation ships an **unlayered** `button { padding: 0 }` rule. Chakra UI v3 emits its button padding inside a CSS `@layer`, and per the cascade, layered styles always lose to unlayered rules **regardless of specificity**. So the theme zeroes the horizontal padding on every Chakra button, leaving the icon with no inset from the rounded edge.

Confirmed in a local WordPress + JointsWP environment: the matched rule setting padding was `button { padding: 0px }` from the theme's `style.css`, and every action button computed `padding: 0px`.

## Fix

Restore horizontal padding on icon-bearing buttons in `wordpress-overrides.css` (the theme-scoped stylesheet that only loads with the plugin), so the icon is inset from the rounded edge:

```css
#oiaa-meetings-root button:has(svg) {
  padding-left: 0.75rem !important;
  padding-right: 0.75rem !important;
}
```

This is scoped to the WordPress override layer, so the standalone app is unaffected.

## Testing

Verified in docker WordPress + JointsWP (matching beta/prod), forced light mode:
- Before: action buttons computed `padding: 0px`, icon inset `0px` (flush against rounded edge)
- After: `padding: 0px 12px`, icon inset `12px` — icon fully contained

Fixes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)
