### PR TITLE
fix: Use colorPalette so category badges render their colors

### DIFF
--- a/src/components/filters/Filter.tsx
+++ b/src/components/filters/Filter.tsx
@@ -67,7 +67,7 @@ function FacetsErrorBox({ onRetry }: FacetsErrorBoxProps) {
         mt={3}
         size="sm"
         variant="outline"
-        colorScheme="orange"
+        colorPalette="orange"
         onClick={onRetry}
       >
         {t("retry")}
@@ -214,7 +214,7 @@ export function Filter({
           <Button
             size="sm"
             variant="ghost"
-            colorScheme="gray"
+            colorPalette="gray"
             onClick={clearAllFilters}
             color="gray.600"
             _dark={{
@@ -242,7 +242,7 @@ export function Filter({
               <Flex align="center" gap={2}>
                 <FaFilter />
                 <Text>{t("filters")}</Text>
-                <Badge colorScheme="blue" variant="solid" borderRadius="full">
+                <Badge colorPalette="blue" variant="solid" borderRadius="full">
                   {activeFilterCount}
                 </Badge>
                 {filtersOpen ? <FaChevronUp /> : <FaChevronDown />}

--- a/src/components/filters/FilterSection.tsx
+++ b/src/components/filters/FilterSection.tsx
@@ -49,7 +49,7 @@ export const FilterSection: React.FC<FilterSectionProps> = ({
       <Flex align="center" gap={2}>
         <Text fontWeight="semibold">{title}</Text>
         {typeof badge === "number" && badge > 0 && (
-          <Badge colorScheme="blue" borderRadius="full">
+          <Badge colorPalette="blue" borderRadius="full">
             {badge}
           </Badge>
         )}

--- a/src/components/meetings/MeetingCategories.tsx
+++ b/src/components/meetings/MeetingCategories.tsx
@@ -88,7 +88,7 @@ const CategoryBadge = ({
   
   return (
     <Badge
-      colorScheme={CATEGORY_COLORS[item.category]}
+      colorPalette={CATEGORY_COLORS[item.category]}
       variant="subtle"
       size={size}
       px={size === 'sm' ? 2 : 3}
@@ -117,7 +117,7 @@ const OverflowIndicator = ({
         <Button
           size={size === 'sm' ? 'xs' : 'sm'}
           variant="ghost"
-          colorScheme="gray"
+          colorPalette="gray"
           px={2}
           py={1}
           h="auto"

--- a/src/routes/group-info.tsx
+++ b/src/routes/group-info.tsx
@@ -286,7 +286,7 @@ function MeetingDisplay({ meeting }: { meeting: Meeting }) {
             {meeting.formats.map((format: string) => (
               <Badge
                 key={format}
-                colorScheme="blue"
+                colorPalette="blue"
                 variant="subtle"
                 px={2}
                 py={1}
@@ -298,7 +298,7 @@ function MeetingDisplay({ meeting }: { meeting: Meeting }) {
             ))}
             {meeting.type && (
               <Badge
-                colorScheme="purple"
+                colorPalette="purple"
                 variant="subtle"
                 px={2}
                 py={1}
@@ -344,7 +344,7 @@ export default function GroupInfo({ loaderData }: Route.ComponentProps) {
     <Layout>
       <Box mb={4}>
         <RouterLink to="/">
-          <Button size="sm" variant="outline" colorScheme="blue">
+          <Button size="sm" variant="outline" colorPalette="blue">
             <FaArrowLeft style={{ marginRight: "8px" }} />
             {t("back_to_meetings")}
           </Button>
@@ -413,7 +413,7 @@ export default function GroupInfo({ loaderData }: Route.ComponentProps) {
                         .map((item) => (
                           <Badge
                             key={`${categoryType}-${item}`}
-                            colorScheme={CATEGORY_COLORS[categoryType]}
+                            colorPalette={CATEGORY_COLORS[categoryType]}
                             variant="subtle"
                             px={2}
                             py={1}


### PR DESCRIPTION
## Summary

The category badges (Open, Big Book, Discussion, English, …) on meeting cards rendered as near-white, borderless pills, barely distinguishable from the white card. Reported as most visible under the JointsWP theme on beta/prod.

## Root cause

Chakra UI v3 (this repo is on `@chakra-ui/react` 3.29.0) renamed the v2 `colorScheme` prop to **`colorPalette`**. `MeetingCategories.tsx` still passed `colorScheme`, which v3 silently ignores — so every badge fell back to the default **gray** palette. The `subtle` variant then produced a `gray.100` (`rgb(244,244,245)`) background with no border, which is nearly white.

Confirmed in a local WordPress + JointsWP environment: every badge computed the identical `gray.100` background regardless of category, instead of the per-category color.

## Fix

Switch `colorScheme` → `colorPalette` on the `CategoryBadge` and the `OverflowIndicator` button (the codebase's `ScheduledFilter.tsx` already uses the v3 `colorPalette` API).

## Testing

Verified in docker WordPress + JointsWP (matching beta/prod), forced light mode:

| Badge | Category | Before (bg) | After (bg) |
| --- | --- | --- | --- |
| Closed / Open | type → cyan | gray.100 `rgb(244,244,245)` | cyan.100 `rgb(207,250,254)` |
| Big Book / Discussion / Speaker | formats → blue | gray.100 | blue.100 `rgb(219,234,254)` |
| English | languages → green | gray.100 | green.100 `rgb(220,252,231)` |

Badges now render with clearly visible, category-distinct colored backgrounds. `npm run typecheck` passes (one pre-existing unrelated error in `CalendarActions.tsx` on main).

Fixes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)
