### PR TITLE
refactor: centralize category keys into meetingTypes.ts

### DIFF
--- a/src/components/filters/CategoryFilter.tsx
+++ b/src/components/filters/CategoryFilter.tsx
@@ -11,7 +11,7 @@ const CATEGORY_COLORS = {
 
 interface CategoryFilterProps<T extends string> {
   displayName: string
-  options: Record<T, string | string[]>
+  options: Record<T, string>
   selected: T[]
   onToggle: (x: string) => void
 }

--- a/src/components/filters/filterGroup.tsx
+++ b/src/components/filters/filterGroup.tsx
@@ -1,9 +1,5 @@
-import React from "react"
-
-import { useTranslation } from "react-i18next"
-
-import type { FacetOptions } from "@/hooks/useFacets"
 import type {
+  CategoryKey,
   Community,
   Feature,
   Format,
@@ -12,8 +8,19 @@ import type {
 } from "@/meetingTypes"
 
 import { CategoryFilter } from "./CategoryFilter"
+import type { FacetOptions } from "@/hooks/useFacets"
 import { FilterSection } from "./FilterSection"
+import React from "react"
 import { TimeFilter } from "./TimeFilter"
+import { useTranslation } from "react-i18next"
+
+interface CategoryFilterEntry {
+  key: CategoryKey
+  title: string
+  options: Record<string, string>
+  selected: string[]
+  onToggle: (x: string) => void
+}
 
 interface RenderFilterGroupsProps {
   filterParams: URLSearchParams
@@ -125,7 +132,7 @@ function FilterGroupsInner({
     )
   }
 
-  const categories = [
+  const categories: CategoryFilterEntry[] = [
     {
       key: "type",
       title: t("filter_meeting_type"),
@@ -164,26 +171,6 @@ function FilterGroupsInner({
   ]
 
   categories.forEach(({ key, title, options, selected, onToggle }) => {
-    let typedOptions: Record<string, string | string[]>
-    switch (key) {
-      case "type":
-        typedOptions = options as Record<Type, string | string[]>
-        break
-      case "formats":
-        typedOptions = options as Record<Format, string | string[]>
-        break
-      case "features":
-        typedOptions = options as Record<Feature, string | string[]>
-        break
-      case "communities":
-        typedOptions = options as Record<Community, string | string[]>
-        break
-      case "languages":
-        typedOptions = options as Record<Language, string | string[]>
-        break
-      default:
-        typedOptions = options
-    }
     const selectedCount = selected.length
     groups.push(
       isMobile ? (
@@ -201,7 +188,7 @@ function FilterGroupsInner({
         >
           <CategoryFilter
             displayName=""
-            options={typedOptions}
+            options={options}
             selected={selected}
             onToggle={onToggle}
           />
@@ -210,7 +197,7 @@ function FilterGroupsInner({
         <CategoryFilter
           key={key}
           displayName={title}
-          options={typedOptions}
+          options={options}
           selected={selected}
           onToggle={onToggle}
         />

--- a/src/components/meetings/MeetingCategories.tsx
+++ b/src/components/meetings/MeetingCategories.tsx
@@ -1,14 +1,3 @@
-import { FaPlus } from "react-icons/fa"
-import { useTranslation } from "react-i18next"
-
-import {
-  PopoverBody,
-  PopoverContent,
-  PopoverRoot,
-  PopoverTrigger,
-} from "@/components/ui/popover"
-import i18n from "@/i18n"
-import type { Meeting } from "@/meetingTypes"
 import {
   Badge,
   Box,
@@ -17,6 +6,18 @@ import {
   Text,
   useBreakpointValue,
 } from "@chakra-ui/react"
+import {
+  PopoverBody,
+  PopoverContent,
+  PopoverRoot,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+
+import { CATEGORY_KEYS } from "@/meetingTypes"
+import { FaPlus } from "react-icons/fa"
+import type { Meeting } from "@/meetingTypes"
+import i18n from "@/i18n"
+import { useTranslation } from "react-i18next"
 
 const CATEGORY_NAMESPACES: Record<string, string> = {
   type: "types",
@@ -56,9 +57,7 @@ const getCategoryItems = (meeting: Meeting) => {
     fullName: string
   }[] = []
 
-  const categories = ["type", "formats", "features", "communities", "languages"] as const
-
-  categories.forEach((category) => {
+  CATEGORY_KEYS.forEach((category) => {
     const value = meeting[category]
     if (!value) return
 

--- a/src/meetingTypes.ts
+++ b/src/meetingTypes.ts
@@ -106,6 +106,16 @@ export interface CategoryMap {
   languages: Language[]
 }
 
+export const CATEGORY_KEYS = [
+  "type",
+  "formats",
+  "features",
+  "communities",
+  "languages",
+] as const satisfies readonly (keyof CategoryMap)[]
+
+export type CategoryKey = (typeof CATEGORY_KEYS)[number]
+
 export interface Meeting extends CategoryMap {
   slug: string
   name: string

--- a/src/routes/group-info.tsx
+++ b/src/routes/group-info.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next"
 import { Link as RouterLink } from "react-router"
 
 import { Layout } from "@/components/Layout"
+import { CATEGORY_KEYS } from "@/meetingTypes"
 import {
   CalendarActions,
   JoinMeetingButton,
@@ -332,14 +333,6 @@ export default function GroupInfo({ loaderData }: Route.ComponentProps) {
 
   const timeInfo = isScheduledMeeting(meeting) ? formatMeetingTimeInfo(meeting) : undefined
 
-  const categories = [
-    "features",
-    "formats",
-    "languages",
-    "communities",
-    "type",
-  ] as const
-
   return (
     <Layout>
       <Box mb={4}>
@@ -396,7 +389,7 @@ export default function GroupInfo({ loaderData }: Route.ComponentProps) {
               {t("meeting_categories")}
             </Heading>
             <SimpleGrid columns={{ base: 1, md: 2 }} gap={4}>
-              {categories.map((categoryType) => {
+              {CATEGORY_KEYS.map((categoryType) => {
                 const value = meeting[categoryType]
                 const items = Array.isArray(value) ? value : [value]
 


### PR DESCRIPTION
Move the duplicated categories array (previously defined in filterGroup.tsx, MeetingCategories.tsx, and group-info.tsx) into a single source of truth in meetingTypes.ts, co-located with the CategoryMap interface it validates against via satisfies.

Also narrows CategoryFilter's options type from Record<T, string | string[]> to Record<T, string>, removing the workaround switch block in filterGroup.tsx that existed solely to satisfy the overly broad type. Uses the new CategoryKey type to annotate the key field in filterGroup's categories array.

The display order (type, formats, features, communities, languages) was already consistent between filterGroup.tsx and MeetingCategories.tsx; group-info.tsx was the outlier and now aligns with the same order.

Fixes #39