### PR TITLE
fix: remove unused t to unblock typecheck

### DIFF
--- a/src/components/meetings/CalendarActions.tsx
+++ b/src/components/meetings/CalendarActions.tsx
@@ -145,7 +145,6 @@ const CalendarOption: React.FC<CalendarOptionProps> = ({
   calendarUrls,
   colorScheme,
 }) => {
-  const { t } = useTranslation()
   return (
     <Flex direction="column" gap={2}>
       <Text fontSize="xs" fontWeight="medium" color="gray.600" _dark={{ color: "gray.400" }}>


### PR DESCRIPTION
## What

Removes an unused `const { t } = useTranslation()` in the `CalendarOption` component in `CalendarActions.tsx`. That component renders calendar links via the module-level `i18n.t(...)`, so the hook's `t` was never read.

## Why

`npm run typecheck` has been failing on `main` (and every branch) since the i18n PR (#347b2f8, Apr 14) with:

```
src/components/meetings/CalendarActions.tsx(148,9): error TS6133: 't' is declared but its value is never read.
```

It went unnoticed because no CI workflow runs `tsc` — the only workflow builds the WordPress plugin via `vite build` (esbuild), which strips types without checking. This one-line removal makes `npm run typecheck` exit 0 again.

## Note

The real root cause is the missing type gate — `main` could regress again silently. Worth adding a `typecheck` step to CI in a follow-up so this doesn't rot. Surfaced while working on #106 / #109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)