### PR TITLE
fix: ensure hours is consistently typed as number

### DIFF
--- a/src/routes/meetings-filtered.tsx
+++ b/src/routes/meetings-filtered.tsx
@@ -19,6 +19,7 @@ import {
 import { getMeetings } from "@/getData"
 import type { Meeting } from "@/meetingTypes"
 import { shuffleWithinTimeSlots } from "@/utils/meetings-utils"
+import { DEFAULT_HOURS_WINDOW } from "@/utils/filter-utils"
 import {
   Box,
   Text,
@@ -28,15 +29,13 @@ import {
 import type { Route } from "./+types/meetings-filtered"
 
 function buildMeetingsQueryString(searchParams: URLSearchParams): string {
-  const hasParams = [...searchParams.entries()].length
-  console.log('🔍 Has search params:', hasParams, 'Params:', [...searchParams.entries()])
+  const paramCount = [...searchParams.entries()].length
   
-  if (!hasParams) {
+  if (!paramCount) {
     const now = DateTime.now().toUTC().toISO()
-    console.log('⏰ Generated timestamp:', now)
     const params = new URLSearchParams({
       start: now,
-      hours: "1",
+      hours: String(DEFAULT_HOURS_WINDOW),
     })
     return `?${params.toString()}`
   }
@@ -50,44 +49,32 @@ function getCacheKey(searchParams: URLSearchParams): string {
 }
 
 // Promise-based cache to deduplicate concurrent loader calls
-const loaderCache = new Map<string, { promise: Promise<{ meetings: Meeting[] }>, callId: string }>()
-
-let loaderCallCount = 0
+const loaderCache = new Map<string, Promise<{ meetings: Meeting[] }>>()
 
 export async function clientLoader({ request }: Route.ClientLoaderArgs): Promise<{ meetings: Meeting[] }> {
-  const callId = String(++loaderCallCount)
-  console.log(`🔵 #${callId} clientLoader called`, 'URL:', request.url)
   const { searchParams } = new URL(request.url)
   const qs = buildMeetingsQueryString(searchParams)
-  console.log(`📝 #${callId} Query string :`, qs)
-  
   const cacheKey = getCacheKey(searchParams)
-  console.log(`🔑 #${callId} Cache key :`, cacheKey)
   
   // Check cache - if exists, return it
   const cachedEntry = loaderCache.get(cacheKey)
   if (cachedEntry) {
-    console.log(`💾 #${callId} Using cached promise from call #${cachedEntry.callId}`)
-    return cachedEntry.promise
+    return cachedEntry
   }
   
   // Create and store promise immediately (before awaiting) to prevent race conditions
   const promise = (async () => {
     const meetings = await getMeetings(qs)
     const shuffled = shuffleWithinTimeSlots(meetings)
-    const firstThree = shuffled.slice(0, 3).map(m => m.slug)
-    console.log(`🟢 #${callId} returning`, shuffled.length, 'meetings (shuffled). First 3:', firstThree)
     return { meetings: shuffled }
   })()
   
   // Store in cache IMMEDIATELY (synchronously) so concurrent calls can see it
-  loaderCache.set(cacheKey, { promise, callId })
-  console.log(`📦 #${callId} Stored new promise in cache`)
+  loaderCache.set(cacheKey, promise)
   
   // Set up cache cleanup after promise resolves
   void promise.finally(() => {
     setTimeout(() => {
-      console.log(`🗑️ #${callId} Clearing cache for key: ${cacheKey}`)
       loaderCache.delete(cacheKey)
     }, 60000) // 60 seconds
   })
@@ -96,7 +83,6 @@ export async function clientLoader({ request }: Route.ClientLoaderArgs): Promise
 }
 
 export default function MeetingsFiltered({ loaderData }: Route.ComponentProps) {
-  console.log('🔴 Component render')
   const { t } = useTranslation()
   const [filterParams, setFilterParams] = useSearchParams()
   const { meetings } = loaderData
@@ -136,7 +122,7 @@ export default function MeetingsFiltered({ loaderData }: Route.ComponentProps) {
     }
 
     window.addEventListener('scroll', handleScroll)
-    return () => window.removeEventListener('scroll', handleScroll)
+    return () => { window.removeEventListener('scroll', handleScroll) }
   }, [visibleMeetingsCount, meetings.length])
 
   return (

--- a/src/utils/filter-utils.test.ts
+++ b/src/utils/filter-utils.test.ts
@@ -1,0 +1,138 @@
+import {
+  DEFAULT_HOURS_WINDOW,
+  createTimeFilterParams,
+  updateTimeParams,
+} from "./filter-utils"
+import {
+  afterEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from "vitest"
+
+import { DateTime } from "luxon"
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+// Pin time to a known Monday at 09:00 local (morning time frame)
+function pinToMondayMorning() {
+  const mockedTime = DateTime.fromObject(
+    { year: 2025, month: 5, day: 5, hour: 9, minute: 0 },
+    { zone: "America/New_York" }
+  ).toJSDate()
+  vi.useFakeTimers()
+  vi.setSystemTime(mockedTime)
+}
+
+// Pin time to a known Monday at 22:00 local.
+// night spans 21:00–03:59, crossing midnight — a fresh day pin avoids
+// ambiguity about which week calculateTargetDate resolves to.
+function pinToMondayNight() {
+  const mockedTime = DateTime.fromObject(
+    { year: 2025, month: 5, day: 5, hour: 22, minute: 0 },
+    { zone: "America/New_York" }
+  ).toJSDate()
+  vi.useFakeTimers()
+  vi.setSystemTime(mockedTime)
+}
+
+describe("createTimeFilterParams", () => {
+  describe("with a known TimeFrame key", () => {
+    test("returns hours as a number, not a string", () => {
+      pinToMondayMorning()
+      const result = createTimeFilterParams("tuesday", "morning")
+      expect(typeof result.hours).toBe("number")
+    })
+
+    test("returns the correct hours for morning (7)", () => {
+      pinToMondayMorning()
+      const result = createTimeFilterParams("tuesday", "morning")
+      expect(result.hours).toBe(7)
+    })
+
+    test("returns the correct hours for midday (2)", () => {
+      pinToMondayMorning()
+      const result = createTimeFilterParams("tuesday", "midday")
+      expect(result.hours).toBe(2)
+    })
+
+    test("returns the correct hours for afternoon (4)", () => {
+      pinToMondayMorning()
+      const result = createTimeFilterParams("tuesday", "afternoon")
+      expect(result.hours).toBe(4)
+    })
+
+    test("returns the correct hours for evening (4)", () => {
+      pinToMondayMorning()
+      const result = createTimeFilterParams("tuesday", "evening")
+      expect(result.hours).toBe(4)
+    })
+
+    test("returns the correct hours for night (7)", () => {
+      pinToMondayNight()
+      const result = createTimeFilterParams("tuesday", "night")
+      expect(result.hours).toBe(7)
+    })
+
+    test("returns a UTC ISO start string", () => {
+      pinToMondayMorning()
+      const result = createTimeFilterParams("tuesday", "morning")
+      expect(result.start).toBeDefined()
+      expect(result.start).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+    })
+  })
+
+  describe("with a custom timeFrame string (HH:MM)", () => {
+    test("returns hours as DEFAULT_HOURS_WINDOW (number)", () => {
+      pinToMondayMorning()
+      const result = createTimeFilterParams("tuesday", "10:00")
+      expect(result.hours).toBe(DEFAULT_HOURS_WINDOW)
+      expect(typeof result.hours).toBe("number")
+    })
+
+    test("DEFAULT_HOURS_WINDOW is 1", () => {
+      expect(DEFAULT_HOURS_WINDOW).toBe(1)
+    })
+
+    test("returns a UTC ISO start string", () => {
+      pinToMondayMorning()
+      const result = createTimeFilterParams("tuesday", "10:00")
+      expect(result.start).toBeDefined()
+      expect(result.start).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
+    })
+  })
+})
+
+describe("updateTimeParams — hours at URLSearchParams boundary", () => {
+  test("hours is stored as a numeric string in URLSearchParams", () => {
+    pinToMondayMorning()
+    const params = updateTimeParams(new URLSearchParams(), "tuesday", "morning")
+    expect(params.get("hours")).toBe("7")
+  })
+
+  test("hours value round-trips correctly for all time frames", () => {
+    pinToMondayMorning()
+    const cases: [string, string][] = [
+      ["morning", "7"],
+      ["midday", "2"],
+      ["afternoon", "4"],
+      ["evening", "4"],
+      ["night", "7"],
+    ]
+    for (const [timeFrame, expected] of cases) {
+      const params = updateTimeParams(new URLSearchParams(), "tuesday", timeFrame)
+      expect(params.get("hours"), `hours for ${timeFrame}`).toBe(expected)
+    }
+  })
+
+  test("hours is a valid numeric string (parseable by parseInt)", () => {
+    pinToMondayMorning()
+    const params = updateTimeParams(new URLSearchParams(), "tuesday", "evening")
+    const hoursStr = params.get("hours")
+    expect(hoursStr).not.toBeNull()
+    expect(Number.isNaN(parseInt(hoursStr ?? "", 10))).toBe(false)
+  })
+})

--- a/src/utils/filter-utils.ts
+++ b/src/utils/filter-utils.ts
@@ -1,5 +1,5 @@
-import type { WeekdayNumbers } from "luxon"
 import { DateTime } from "luxon"
+import type { WeekdayNumbers } from "luxon"
 
 export const TIME_FRAMES = {
   morning: { start: "04:00", end: "10:59", hours: 7 },
@@ -10,6 +10,9 @@ export const TIME_FRAMES = {
 } as const
 
 export type TimeFrame = keyof typeof TIME_FRAMES
+
+/** Default query window (in hours) used when no named TimeFrame applies (e.g. a custom HH:MM time string). */
+export const DEFAULT_HOURS_WINDOW = 1
 
 export const WEEKDAY_MAP: Record<string, number> = {
   monday: 1,
@@ -75,7 +78,7 @@ export function calculateTargetDate(day: string, timeFrame: string): DateTime {
   return targetDate
 }
 
-export function createTimeFilterParams(day: string, timeFrame: string): { start?: string; hours: string } {
+export function createTimeFilterParams(day: string, timeFrame: string): { start?: string; hours: number } {
   const targetDate = calculateTargetDate(day, timeFrame)
   
   if (timeFrame in TIME_FRAMES) {
@@ -83,14 +86,13 @@ export function createTimeFilterParams(day: string, timeFrame: string): { start?
     const utcStart = targetDate.toUTC().toISO()
     return {
       start: utcStart ?? undefined,
-      hours: hours.toString(),
+      hours,
     }
   } else {
-
     const utcStart = targetDate.toUTC().toISO()
     return {
       start: utcStart ?? undefined,
-      hours: "1",
+      hours: DEFAULT_HOURS_WINDOW,
     }
   }
 }
@@ -122,7 +124,7 @@ export function updateTimeParams(
   if (timeParams.start) {
     next.set("start", timeParams.start)
   }
-  next.set("hours", timeParams.hours)
+  next.set("hours", String(timeParams.hours))
   
   return next
 }


### PR DESCRIPTION
createTimeFilterParams now returns hours as number (consistent with TIME_FRAMES values). String conversion is deferred to the single URLSearchParams.set() call site in updateTimeParams and buildMeetingsQueryString.

Extracts DEFAULT_HOURS_WINDOW = 1 named constant to replace the magic number used in the custom timeFrame fallback path and in the default query string builder.

Removes debug console.log statements left over from development. Simplifies loaderCache map type now that the callId debug field is gone.

Adds filter-utils.test.ts covering createTimeFilterParams (all 5 TimeFrame keys + custom HH:MM fallback, type assertions) and updateTimeParams (URL boundary string conversion, all time frames).

Fixes #32