### PR TITLE
fix: neutralize theme form-control margins in meetings root

### DIFF
--- a/wordpress-plugin/assets/wordpress-overrides.css
+++ b/wordpress-plugin/assets/wordpress-overrides.css
@@ -236,6 +236,8 @@
   /* Do NOT reset padding, background, border - these are set by components */
   font-family: inherit;
   box-sizing: border-box;
+  /* Foundation/theme styles often add margin-bottom to form controls */
+  margin: 0 !important;
 }
 
 /* ============================================================


### PR DESCRIPTION
**Summary**
This PR fixes vertical misalignment in the Day and Time dropdowns on staging by removing theme-injected form-control margins inside the meetings app root.

**Problem**
On staging site, the Day and Time select controls looked visually off-center because the wrapper was taller than the select itself.

**Root cause**
The WordPress theme applies a default bottom margin to native form controls [select margin-bottom: 1rem], which inflated the dropdown wrapper height.

**Validation**
Before: select margin-bottom 16px, wrapper height 57px
After: select margin-bottom 0px, wrapper height 41px
Visual alignment corrected for Day/Time controls in staging preview
**Related issue**
Closes #117

**Testing**
Open meetings page on staging.
Check Day and Time dropdowns in Filters panel on desktop.
Confirm controls appear vertically centered.
Confirm no style regressions outside the meetings app area.