### PR TITLE
docs: compare MIT vs GNU license options

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,11 @@ Currently, two official plugins are available:
 
 ## License
 
-[MIT](LICENSE)
+This project does not yet include an open source license file.
+
+To compare license options under consideration (`MIT` and `GNU GPL`), see:
+
+- `docs/license-options.md`
 
 ---
 

--- a/docs/license-options.md
+++ b/docs/license-options.md
@@ -1,0 +1,68 @@
+# Open Source License Options (MIT vs GNU GPL)
+
+This document compares two license options for OIAA Direct before introducing Sentry.
+
+## Why this matters
+
+Adding an explicit open source license clarifies:
+
+- How others can use and modify this project
+- Whether derivative works must remain open source
+- Contributor and organization expectations
+
+Without a license file, others technically have very limited rights to reuse the code.
+
+## Option 1: MIT License
+
+### Pros
+
+- Very permissive and simple
+- Easy for companies and nonprofits to adopt
+- Low legal friction for integrations, forks, and plugins
+- Common and widely understood across JavaScript ecosystems
+
+### Cons
+
+- Allows closed-source forks and proprietary redistribution
+- Does not require improvements to be contributed back
+
+### Best fit when
+
+- The goal is broad adoption and minimal barriers
+- The project team is comfortable with commercial/proprietary reuse
+
+## Option 2: GNU GPL (typically GPL-3.0-or-later)
+
+### Pros
+
+- Strong copyleft: derivative works must remain open source under GPL
+- Encourages sharing improvements with the community
+- Protects against proprietary relicensing of derivative distributions
+
+### Cons
+
+- Higher legal/compliance overhead for adopters
+- Some organizations avoid GPL due to policy constraints
+- Can reduce adoption in mixed-license or proprietary environments
+
+### Best fit when
+
+- The goal is to ensure downstream derivatives remain open source
+- The project prioritizes reciprocity over maximum adoption
+
+## Recommendation framing for this project
+
+If your priority is broad ecosystem adoption and low-friction integration, MIT is usually the pragmatic default.
+
+If your priority is ensuring derivative distributions stay open source, GPL-3.0-or-later is the stronger policy tool.
+
+## Proposed decision process
+
+1. Confirm project goals: maximize adoption vs enforce copyleft reciprocity
+2. Confirm compatibility with dependencies and WordPress distribution expectations
+3. Approve one license in a follow-up PR that adds a top-level `LICENSE` file
+4. Update `README.md` to reference the final license
+
+## Note about Sentry
+
+Sentry usage itself does not require choosing MIT vs GPL specifically, but having an explicit OSI-approved license improves clarity for contributors and downstream users.


### PR DESCRIPTION
## Summary
This PR starts an explicit licensing discussion so we can choose an open source license before/while evaluating Sentry usage.

## What changed
- Added `docs/license-options.md` with a side-by-side comparison of:
  - MIT (permissive)
  - GNU GPL (copyleft)
- Updated `README.md` to remove the current MIT placeholder reference and point to the new options document.

## Why
The repository currently has no top-level `LICENSE` file. Without one, downstream reuse rights are unclear. This PR creates a clear decision artifact without forcing a license choice yet.

## Decision needed
Please choose one direction in follow-up:
1. MIT for broad adoption and low-friction reuse
2. GPL-3.0-or-later for stronger copyleft reciprocity

Once chosen, we can open a short follow-up PR adding `LICENSE` and updating README accordingly.