### PR TITLE
docs: discuss MIT vs GNU license options (no license selected yet)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 code4recovery
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Currently, two official plugins are available:
 
 This project is licensed under the [MIT License](LICENSE).
 
-code4recovery encourages MIT licensing across its repositories to maximize adoption and reduce legal friction.
+Code for Recovery encourages MIT licensing across its repositories to maximize adoption and reduce legal friction.
 
 Note: the TSML WP plugin project is a GNU-license outlier because GPL compatibility is required for inclusion in the WordPress plugin ecosystem.
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,11 @@ Currently, two official plugins are available:
 
 ## License
 
-License decision pending. This project does not yet include a top-level `LICENSE` file.
+This project is licensed under the [MIT License](LICENSE).
+
+code4recovery encourages MIT licensing across its repositories to maximize adoption and reduce legal friction.
+
+Note: the TSML WP plugin project is a GNU-license outlier because GPL compatibility is required for inclusion in the WordPress plugin ecosystem.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Currently, two official plugins are available:
 
 ## License
 
-[MIT](LICENSE)
+License decision pending. This project does not yet include a top-level `LICENSE` file.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "oiaa-direct",
   "private": true,
   "version": "1.3.2",
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "react-router dev",


### PR DESCRIPTION
## Summary
This PR adds MIT license by  adding the required repository licensing files/metadata.

## Changes
- Added top-level MIT license text in `LICENSE`
- Updated README License section to link to MIT
- Added `"license": "MIT"` to `package.json`

## Why MIT
Code4recovery generally encourages MIT across repositories because it is permissive, simple, and lowers adoption friction.

## MIT vs GNU (context from discussion)
### MIT
Pros:
- Very permissive and easy to understand
- Low compliance overhead
- Broad compatibility for nonprofits, companies, and integrators

Cons:
- Allows proprietary forks
- Does not require contributions to be upstreamed

### GNU GPL
Pros:
- Copyleft keeps distributed derivatives open
- Encourages reciprocal sharing of modifications

Cons:
- Higher compliance burden
- Can reduce adoption for teams with restrictive policy requirements

## Exception Note
The TSML WordPress plugin project is an intentional GNU outlier because GPL compatibility is required for participation in the WordPress plugin ecosystem.